### PR TITLE
大佬，发现您的项目引入了taglibs:standard@1.1.2组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   	<modelVersion>4.0.0</modelVersion>
   	<groupId>cn.edu.xtu.lostfound</groupId>
@@ -135,7 +136,7 @@
 		<dependency>
     		<groupId>taglibs</groupId>
     		<artifactId>standard</artifactId>
-    		<version>1.1.2</version>
+    		<version>1.2.3</version>
 		</dependency>
 		
 		<!-- log4j日志库 -->


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Standard Taglibs 代码注入漏洞
缺陷组件：taglibs:standard@1.1.2
漏洞编号：CVE-2015-0254
漏洞描述：Apache Standard Taglibs是美国阿帕奇（Apache）软件基金会的一个JSP标准标签库（JSTL）规范的实现。
Apache Standard Taglibs 1.2.3之前版本中存在安全漏洞。远程攻击者可借助JSTL XML标签中特制的XSLT扩展利用该漏洞执行任意代码，或实施外部XML实体（XXE）攻击。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2015-01459
影响范围：(∞, 1.2.3)
最小修复版本：1.2.3
缺陷组件引入路径：cn.edu.xtu.lostfound:CampusLostAndFound@0.0.1-SNAPSHOT->taglibs:standard@1.1.2
```
另外我运行这个项目时，IDE的安全插件提示还有68个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pc2191